### PR TITLE
Fix add baseURL prefix if specified

### DIFF
--- a/hubspot.go
+++ b/hubspot.go
@@ -115,7 +115,7 @@ func (c *HubspotClient) NewRequest(method, urlStr string, body interface{}) (*ht
 		return nil, fmt.Errorf("urlStr must have begin with a slash, but %q does not", urlStr)
 	}
 
-	u, err := c.BaseURL.Parse(urlStr)
+	u, err := c.BaseURL.Parse(c.BaseURL.Path + urlStr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For test purpose, we can mock several endpoints. To join
hubspot endpoints, we can have an URL with a prefix path
like http://fake-endpoints.qa/hubspot.

This patch adds the base URL path to the request.

Signed-off-by: Nicolas Gelot <nicolas.gelot@vadesecure.com>